### PR TITLE
Use a persistent TCP connection for issuing HTTP requests to the runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,6 @@ opam-steps: &opam-steps
         command: |
           opam install reason
           opam install alcotest
-          opam pin add httpaf -y git+https://github.com/anmonteiro/httpaf#anmonteiro/persistent-client
-          opam pin add httpaf-lwt-unix -y git+https://github.com/anmonteiro/httpaf#anmonteiro/persistent-client
           opam install -t --deps-only .
     - save_cache:
         <<: *common_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ opam-steps: &opam-steps
         command: |
           opam install reason
           opam install alcotest
-          opam pin add httpaf -y --dev-repo
-          opam pin add -y httpaf-lwt-unix git+https://github.com/inhabitedtype/httpaf
+          opam pin add httpaf -y git+https://github.com/anmonteiro/httpaf#anmonteiro/persistent-client
+          opam pin add httpaf-lwt-unix -y git+https://github.com/anmonteiro/httpaf#anmonteiro/persistent-client
           opam install -t --deps-only .
     - save_cache:
         <<: *common_cache_key

--- a/esy.json
+++ b/esy.json
@@ -25,11 +25,10 @@
   },
   "resolutions": {
     "@opam/conf-libev": "esy-packages/libev:package.json#0b5eb66",
-    "@opam/httpaf": "anmonteiro/httpaf:httpaf.opam#08ecb42",
-    "@opam/httpaf-lwt-unix": "anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42",
+    "@opam/httpaf": "anmonteiro/httpaf:httpaf.opam#7c5d991",
+    "@opam/httpaf-lwt": "anmonteiro/httpaf:httpaf-lwt.opam#7c5d991",
+    "@opam/httpaf-lwt-unix": "anmonteiro/httpaf:httpaf-lwt-unix.opam#7c5d991",
     "@opam/reason": "facebook/reason:reason.opam#f584e86",
-    "@opam/ppx_tools": "ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4",
-    "@opam/ppx_deriving": "ocaml-ppx/ppx_deriving:ppx_deriving.opam#403d384",
-    "@opam/ppx_deriving_yojson": "anmonteiro/ppx_deriving_yojson:ppx_deriving_yojson.opam#3e16cd2"
+    "@opam/ppx_deriving_yojson": "ocaml-ppx/ppx_deriving_yojson:ppx_deriving_yojson.opam#a39728f"
   }
 }

--- a/esy.json
+++ b/esy.json
@@ -25,8 +25,8 @@
   },
   "resolutions": {
     "@opam/conf-libev": "esy-packages/libev:package.json#0b5eb66",
-    "@opam/httpaf": "inhabitedtype/httpaf:httpaf.opam#fa9dc4e",
-    "@opam/httpaf-lwt-unix": "inhabitedtype/httpaf:httpaf-lwt-unix.opam#fa9dc4e",
+    "@opam/httpaf": "anmonteiro/httpaf:httpaf.opam#08ecb42",
+    "@opam/httpaf-lwt-unix": "anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42",
     "@opam/reason": "facebook/reason:reason.opam#f584e86",
     "@opam/ppx_tools": "ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4",
     "@opam/ppx_deriving": "ocaml-ppx/ppx_deriving:ppx_deriving.opam#403d384",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4d15df27f87ecbc80fbc80f6ff7dcdcb",
+  "checksum": "016eb5a727641d7f55b59be6ad6fca0d",
   "root": "aws-lambda-ocaml-runtime@link-dev:./esy.json",
   "node": {
     "ocaml@4.8.0@d41d8cd9": {
@@ -25,9 +25,9 @@
       "dependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/yojson@opam:1.7.0@2d92307e",
         "@opam/uri@opam:2.2.1@6bd26f86",
-        "@opam/ppx_deriving_yojson@github:anmonteiro/ppx_deriving_yojson:ppx_deriving_yojson.opam#3e16cd2@d41d8cd9",
+        "@opam/ppx_deriving_yojson@github:ocaml-ppx/ppx_deriving_yojson:ppx_deriving_yojson.opam#a39728f@d41d8cd9",
         "@opam/lwt@opam:4.2.1@c1888ec9", "@opam/logs@opam:0.6.3@80c08d15",
-        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42@d41d8cd9",
+        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#7c5d991@d41d8cd9",
         "@opam/dune@opam:1.10.0@b15ce221",
         "@opam/conf-libev@archive:http://dist.schmorp.de/libev/Attic/libev-4.27.tar.gz#sha1:b67aff18f6f1ffec4422e188c98d9fe458c5ed0b@6c404c36",
         "@opam/base64@opam:3.2.0@e1bac209",
@@ -514,23 +514,28 @@
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@107a1ff4"
       ]
     },
-    "@opam/ppx_tools@github:ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4@d41d8cd9": {
-      "id":
-        "@opam/ppx_tools@github:ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4@d41d8cd9",
+    "@opam/ppx_tools@opam:5.2+4.08.0@964f70cb": {
+      "id": "@opam/ppx_tools@opam:5.2+4.08.0@964f70cb",
       "name": "@opam/ppx_tools",
-      "version": "github:ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4",
+      "version": "opam:5.2+4.08.0",
       "source": {
         "type": "install",
-        "source": [ "github:ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4" ]
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/3f/3f911ebddad5eb4dd279b303a34d9493#md5:3f911ebddad5eb4dd279b303a34d9493",
+          "archive:https://github.com/ocaml-ppx/ppx_tools/archive/5.2+4.08.0.tar.gz#md5:3f911ebddad5eb4dd279b303a34d9493"
+        ],
+        "opam": {
+          "name": "ppx_tools",
+          "version": "5.2+4.08.0",
+          "path": "esy.lock/opam/ppx_tools.5.2+4.08.0"
+        }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [
-        "ocaml@4.8.0@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5"
-      ]
+      "devDependencies": [ "ocaml@4.8.0@d41d8cd9" ]
     },
     "@opam/ppx_sexp_conv@opam:v0.12.0@6aa153b5": {
       "id": "@opam/ppx_sexp_conv@opam:v0.12.0@6aa153b5",
@@ -562,49 +567,54 @@
         "@opam/base@opam:v0.12.2@e209c8f2"
       ]
     },
-    "@opam/ppx_deriving_yojson@github:anmonteiro/ppx_deriving_yojson:ppx_deriving_yojson.opam#3e16cd2@d41d8cd9": {
+    "@opam/ppx_deriving_yojson@github:ocaml-ppx/ppx_deriving_yojson:ppx_deriving_yojson.opam#a39728f@d41d8cd9": {
       "id":
-        "@opam/ppx_deriving_yojson@github:anmonteiro/ppx_deriving_yojson:ppx_deriving_yojson.opam#3e16cd2@d41d8cd9",
+        "@opam/ppx_deriving_yojson@github:ocaml-ppx/ppx_deriving_yojson:ppx_deriving_yojson.opam#a39728f@d41d8cd9",
       "name": "@opam/ppx_deriving_yojson",
       "version":
-        "github:anmonteiro/ppx_deriving_yojson:ppx_deriving_yojson.opam#3e16cd2",
+        "github:ocaml-ppx/ppx_deriving_yojson:ppx_deriving_yojson.opam#a39728f",
       "source": {
         "type": "install",
         "source": [
-          "github:anmonteiro/ppx_deriving_yojson:ppx_deriving_yojson.opam#3e16cd2"
+          "github:ocaml-ppx/ppx_deriving_yojson:ppx_deriving_yojson.opam#a39728f"
         ]
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/yojson@opam:1.7.0@2d92307e",
         "@opam/result@opam:1.4@7add0d71", "@opam/ppxfind@opam:1.3@a7b3cc46",
-        "@opam/ppx_tools@github:ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4@d41d8cd9",
-        "@opam/ppx_deriving@github:ocaml-ppx/ppx_deriving:ppx_deriving.opam#403d384@d41d8cd9",
+        "@opam/ppx_tools@opam:5.2+4.08.0@964f70cb",
+        "@opam/ppx_deriving@opam:4.4@35f44479",
         "@opam/dune@opam:1.10.0@b15ce221", "@opam/cppo@opam:1.6.6@25eb99ce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/yojson@opam:1.7.0@2d92307e",
         "@opam/result@opam:1.4@7add0d71",
-        "@opam/ppx_deriving@github:ocaml-ppx/ppx_deriving:ppx_deriving.opam#403d384@d41d8cd9"
+        "@opam/ppx_deriving@opam:4.4@35f44479"
       ]
     },
-    "@opam/ppx_deriving@github:ocaml-ppx/ppx_deriving:ppx_deriving.opam#403d384@d41d8cd9": {
-      "id":
-        "@opam/ppx_deriving@github:ocaml-ppx/ppx_deriving:ppx_deriving.opam#403d384@d41d8cd9",
+    "@opam/ppx_deriving@opam:4.4@35f44479": {
+      "id": "@opam/ppx_deriving@opam:4.4@35f44479",
       "name": "@opam/ppx_deriving",
-      "version": "github:ocaml-ppx/ppx_deriving:ppx_deriving.opam#403d384",
+      "version": "opam:4.4",
       "source": {
         "type": "install",
         "source": [
-          "github:ocaml-ppx/ppx_deriving:ppx_deriving.opam#403d384"
-        ]
+          "archive:https://opam.ocaml.org/cache/sha256/c2/c2d85af4cb65a1f163f624590fb0395a164bbfd0d05082092526b669e66bcc34#sha256:c2d85af4cb65a1f163f624590fb0395a164bbfd0d05082092526b669e66bcc34",
+          "archive:https://github.com/ocaml-ppx/ppx_deriving/archive/v4.4.tar.gz#sha256:c2d85af4cb65a1f163f624590fb0395a164bbfd0d05082092526b669e66bcc34"
+        ],
+        "opam": {
+          "name": "ppx_deriving",
+          "version": "4.4",
+          "path": "esy.lock/opam/ppx_deriving.4.4"
+        }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/result@opam:1.4@7add0d71",
         "@opam/ppxfind@opam:1.3@a7b3cc46",
-        "@opam/ppx_tools@github:ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4@d41d8cd9",
+        "@opam/ppx_tools@opam:5.2+4.08.0@964f70cb",
         "@opam/ppx_derivers@opam:1.2.1@0b458500",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@107a1ff4",
         "@opam/dune@opam:1.10.0@b15ce221", "@opam/cppo@opam:1.6.6@25eb99ce",
@@ -612,7 +622,7 @@
       ],
       "devDependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/result@opam:1.4@7add0d71",
-        "@opam/ppx_tools@github:ocaml-ppx/ppx_tools:ppx_tools.opam#331fbc4@d41d8cd9",
+        "@opam/ppx_tools@opam:5.2+4.08.0@964f70cb",
         "@opam/ppx_derivers@opam:1.2.1@0b458500",
         "@opam/ocaml-migrate-parsetree@opam:1.4.0@107a1ff4",
         "@opam/dune@opam:1.10.0@b15ce221"
@@ -988,36 +998,59 @@
         "ocaml@4.8.0@d41d8cd9", "@opam/dune@opam:1.10.0@b15ce221"
       ]
     },
-    "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42@d41d8cd9": {
+    "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#7c5d991@d41d8cd9": {
       "id":
-        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42@d41d8cd9",
+        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#7c5d991@d41d8cd9",
       "name": "@opam/httpaf-lwt-unix",
-      "version": "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42",
+      "version": "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#7c5d991",
       "source": {
         "type": "install",
-        "source": [ "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42" ]
+        "source": [ "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#7c5d991" ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.0@d41d8cd9", "@opam/lwt@opam:4.2.1@c1888ec9",
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#08ecb42@d41d8cd9",
+        "ocaml@4.8.0@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
+        "@opam/lwt@opam:4.2.1@c1888ec9",
+        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#7c5d991@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#7c5d991@d41d8cd9",
         "@opam/faraday-lwt-unix@opam:0.7.0@b0dea04f",
         "@opam/dune@opam:1.10.0@b15ce221", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/lwt@opam:4.2.1@c1888ec9",
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#08ecb42@d41d8cd9",
+        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#7c5d991@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#7c5d991@d41d8cd9",
         "@opam/faraday-lwt-unix@opam:0.7.0@b0dea04f"
       ]
     },
-    "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#08ecb42@d41d8cd9": {
+    "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#7c5d991@d41d8cd9": {
       "id":
-        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#08ecb42@d41d8cd9",
-      "name": "@opam/httpaf",
-      "version": "github:anmonteiro/httpaf:httpaf.opam#08ecb42",
+        "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#7c5d991@d41d8cd9",
+      "name": "@opam/httpaf-lwt",
+      "version": "github:anmonteiro/httpaf:httpaf-lwt.opam#7c5d991",
       "source": {
         "type": "install",
-        "source": [ "github:anmonteiro/httpaf:httpaf.opam#08ecb42" ]
+        "source": [ "github:anmonteiro/httpaf:httpaf-lwt.opam#7c5d991" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.0@d41d8cd9", "@opam/lwt@opam:4.2.1@c1888ec9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#7c5d991@d41d8cd9",
+        "@opam/dune@opam:1.10.0@b15ce221", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.0@d41d8cd9", "@opam/lwt@opam:4.2.1@c1888ec9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#7c5d991@d41d8cd9"
+      ]
+    },
+    "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#7c5d991@d41d8cd9": {
+      "id":
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#7c5d991@d41d8cd9",
+      "name": "@opam/httpaf",
+      "version": "github:anmonteiro/httpaf:httpaf.opam#7c5d991",
+      "source": {
+        "type": "install",
+        "source": [ "github:anmonteiro/httpaf:httpaf.opam#7c5d991" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e222521fbeb4b6734a47daeb4babc36e",
+  "checksum": "4d15df27f87ecbc80fbc80f6ff7dcdcb",
   "root": "aws-lambda-ocaml-runtime@link-dev:./esy.json",
   "node": {
     "ocaml@4.8.0@d41d8cd9": {
@@ -27,7 +27,7 @@
         "@opam/uri@opam:2.2.1@6bd26f86",
         "@opam/ppx_deriving_yojson@github:anmonteiro/ppx_deriving_yojson:ppx_deriving_yojson.opam#3e16cd2@d41d8cd9",
         "@opam/lwt@opam:4.2.1@c1888ec9", "@opam/logs@opam:0.6.3@80c08d15",
-        "@opam/httpaf-lwt-unix@github:inhabitedtype/httpaf:httpaf-lwt-unix.opam#fa9dc4e@d41d8cd9",
+        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42@d41d8cd9",
         "@opam/dune@opam:1.10.0@b15ce221",
         "@opam/conf-libev@archive:http://dist.schmorp.de/libev/Attic/libev-4.27.tar.gz#sha1:b67aff18f6f1ffec4422e188c98d9fe458c5ed0b@6c404c36",
         "@opam/base64@opam:3.2.0@e1bac209",
@@ -729,7 +729,7 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.8.0@d41d8cd9", "@opam/conf-m4@opam:1@dd7dde42",
+        "ocaml@4.8.0@d41d8cd9", "@opam/conf-m4@opam:1@da6f4f44",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.8.0@d41d8cd9" ]
@@ -988,38 +988,36 @@
         "ocaml@4.8.0@d41d8cd9", "@opam/dune@opam:1.10.0@b15ce221"
       ]
     },
-    "@opam/httpaf-lwt-unix@github:inhabitedtype/httpaf:httpaf-lwt-unix.opam#fa9dc4e@d41d8cd9": {
+    "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42@d41d8cd9": {
       "id":
-        "@opam/httpaf-lwt-unix@github:inhabitedtype/httpaf:httpaf-lwt-unix.opam#fa9dc4e@d41d8cd9",
+        "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42@d41d8cd9",
       "name": "@opam/httpaf-lwt-unix",
-      "version": "github:inhabitedtype/httpaf:httpaf-lwt-unix.opam#fa9dc4e",
+      "version": "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42",
       "source": {
         "type": "install",
-        "source": [
-          "github:inhabitedtype/httpaf:httpaf-lwt-unix.opam#fa9dc4e"
-        ]
+        "source": [ "github:anmonteiro/httpaf:httpaf-lwt-unix.opam#08ecb42" ]
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/lwt@opam:4.2.1@c1888ec9",
-        "@opam/httpaf@github:inhabitedtype/httpaf:httpaf.opam#fa9dc4e@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#08ecb42@d41d8cd9",
         "@opam/faraday-lwt-unix@opam:0.7.0@b0dea04f",
         "@opam/dune@opam:1.10.0@b15ce221", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/lwt@opam:4.2.1@c1888ec9",
-        "@opam/httpaf@github:inhabitedtype/httpaf:httpaf.opam#fa9dc4e@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#08ecb42@d41d8cd9",
         "@opam/faraday-lwt-unix@opam:0.7.0@b0dea04f"
       ]
     },
-    "@opam/httpaf@github:inhabitedtype/httpaf:httpaf.opam#fa9dc4e@d41d8cd9": {
+    "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#08ecb42@d41d8cd9": {
       "id":
-        "@opam/httpaf@github:inhabitedtype/httpaf:httpaf.opam#fa9dc4e@d41d8cd9",
+        "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#08ecb42@d41d8cd9",
       "name": "@opam/httpaf",
-      "version": "github:inhabitedtype/httpaf:httpaf.opam#fa9dc4e",
+      "version": "github:anmonteiro/httpaf:httpaf.opam#08ecb42",
       "source": {
         "type": "install",
-        "source": [ "github:inhabitedtype/httpaf:httpaf.opam#fa9dc4e" ]
+        "source": [ "github:anmonteiro/httpaf:httpaf.opam#08ecb42" ]
       },
       "overrides": [],
       "dependencies": [
@@ -1264,8 +1262,8 @@
         "ocaml@4.8.0@d41d8cd9", "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-which@opam:1@56319cdb": {
-      "id": "@opam/conf-which@opam:1@56319cdb",
+    "@opam/conf-which@opam:1@576f0c6d": {
+      "id": "@opam/conf-which@opam:1@576f0c6d",
       "name": "@opam/conf-which",
       "version": "opam:1",
       "source": {
@@ -1281,8 +1279,8 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "@opam/conf-m4@opam:1@dd7dde42": {
-      "id": "@opam/conf-m4@opam:1@dd7dde42",
+    "@opam/conf-m4@opam:1@da6f4f44": {
+      "id": "@opam/conf-m4@opam:1@da6f4f44",
       "name": "@opam/conf-m4",
       "version": "opam:1",
       "source": {
@@ -1358,7 +1356,7 @@
       "dependencies": [
         "ocaml@4.8.0@d41d8cd9", "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/easy-format@opam:1.3.1@9abfd4ed",
-        "@opam/conf-which@opam:1@56319cdb",
+        "@opam/conf-which@opam:1@576f0c6d",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [

--- a/esy.lock/opam/conf-m4.1/opam
+++ b/esy.lock/opam/conf-m4.1/opam
@@ -6,8 +6,7 @@ authors: "GNU Project"
 license: "GPL-3"
 build: [["sh" "-exc" "echo | m4"]]
 depexts: [
-  ["m4"] {os-distribution = "debian"}
-  ["m4"] {os-distribution = "ubuntu"}
+  ["m4"] {os-family = "debian"}
   ["m4"] {os-distribution = "fedora"}
   ["m4"] {os-distribution = "rhel"}
   ["m4"] {os-distribution = "centos"}

--- a/esy.lock/opam/conf-which.1/opam
+++ b/esy.lock/opam/conf-which.1/opam
@@ -9,8 +9,7 @@ depexts: [
   ["which"] {os-distribution = "centos"}
   ["which"] {os-distribution = "fedora"}
   ["which"] {os-family = "suse"}
-  ["debianutils"] {os-distribution = "debian"}
-  ["debianutils"] {os-distribution = "ubuntu"}
+  ["debianutils"] {os-family = "debian"}
   ["which"] {os-distribution = "nixos"}
   ["which"] {os-distribution = "arch"}
 ]

--- a/esy.lock/opam/ppx_deriving.4.4/opam
+++ b/esy.lock/opam/ppx_deriving.4.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version >= "4.03"}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune"     {build >= "1.6.3"}
+  "cppo"     {build}
+  "ppxfind"  {build}
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppx_tools"  {>= "4.02.3"}
+  "result"
+  "ounit"      {with-test}
+  "ocaml" {>= "4.02" & < "4.09.0"}
+]
+synopsis: "Type-driven code generation for OCaml >=4.02.2"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src: "https://github.com/ocaml-ppx/ppx_deriving/archive/v4.4.tar.gz"
+  checksum: "sha256=c2d85af4cb65a1f163f624590fb0395a164bbfd0d05082092526b669e66bcc34"}

--- a/esy.lock/opam/ppx_tools.5.2+4.08.0/opam
+++ b/esy.lock/opam/ppx_tools.5.2+4.08.0/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Tools for authors of ppx rewriters and other syntactic tools"
+maintainer: "alain.frisch@lexifi.com"
+authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git"
+tags: [ "syntax" ]
+build: [[make "all"]]
+install: [[make "install"]]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build & >= "1.5.0"}
+]
+url {
+  src: "https://github.com/ocaml-ppx/ppx_tools/archive/5.2+4.08.0.tar.gz"
+  checksum: "md5=3f911ebddad5eb4dd279b303a34d9493"
+}

--- a/examples/api-gateway/Dockerfile
+++ b/examples/api-gateway/Dockerfile
@@ -31,61 +31,23 @@ ENV PATH=/esy/bin:$PATH
 RUN mkdir /app
 WORKDIR /app
 
+RUN echo ' \
+{\
+  "name": "package-base", \
+  "dependencies": { \
+    "ocaml": "~4.7.1000", \
+    "@opam/dune": "*" \
+  } \
+} \
+' > esy.json
+
+RUN esy
+
 COPY esy.json esy.json
 COPY esy.lock esy.lock
 
 RUN esy fetch
-RUN esy build-package @esy-ocaml/substs
-RUN esy build-package @opam/conf-m4
-RUN esy build-package ocaml@4.7.1003
-RUN esy build-package @opam/ocamlfind
-RUN esy build-package @opam/base-bytes
-RUN esy build-package @opam/ocamlbuild
-RUN esy build-package @opam/base-threads
-RUN esy build-package @opam/base-unix
-RUN esy build-package @opam/dune
-RUN esy build-package @opam/jbuilder
-RUN esy build-package @opam/result
-RUN esy build-package @opam/topkg
-RUN esy build-package @opam/astring
-RUN esy build-package @opam/cmdliner
-RUN esy build-package @opam/uchar
-RUN esy build-package @opam/fmt
-RUN esy build-package @opam/uuidm
-RUN esy build-package @opam/alcotest
-RUN esy build-package @opam/base-bigarray
-RUN esy build-package @opam/bigstringaf
-RUN esy build-package @opam/faraday
-RUN esy build-package @opam/cppo
-RUN esy build-package @opam/lwt
-RUN esy build-package @opam/faraday-lwt
-RUN esy build-package @opam/faraday-lwt-unix
-RUN esy build-package @opam/angstrom
-RUN esy build-package @opam/httpaf
-RUN esy build-package @opam/httpaf-lwt
-RUN esy build-package @opam/logs
-RUN esy build-package @opam/cppo_ocamlbuild
-RUN esy build-package @opam/ocaml-migrate-parsetree
-RUN esy build-package @opam/ppx_derivers
-RUN esy build-package @opam/ppx_tools
-RUN esy build-package @opam/ppx_deriving
-RUN esy build-package @opam/ppxfind
-RUN esy build-package @opam/conf-which
-RUN esy build-package @opam/easy-format
-RUN esy build-package @opam/biniou
-RUN esy build-package @opam/yojson
-RUN esy build-package @opam/ppx_deriving_yojson
-RUN esy build-package @opam/sexplib0
-RUN esy build-package @opam/base
-RUN esy build-package @opam/ocaml-compiler-libs
-RUN esy build-package @opam/stdio
-RUN esy build-package @opam/ppxlib
-RUN esy build-package @opam/ppx_sexp_conv
-RUN esy build-package @opam/seq
-RUN esy build-package @opam/re
-RUN esy build-package @opam/stringext
-RUN esy build-package @opam/uri
-RUN esy build-package @opam/base64
+RUN esy true
 
 COPY . .
 

--- a/examples/asynchronous-handler/Dockerfile
+++ b/examples/asynchronous-handler/Dockerfile
@@ -31,61 +31,23 @@ ENV PATH=/esy/bin:$PATH
 RUN mkdir /app
 WORKDIR /app
 
+RUN echo ' \
+{\
+  "name": "package-base", \
+  "dependencies": { \
+    "ocaml": "~4.7.1000", \
+    "@opam/dune": "*" \
+  } \
+} \
+' > esy.json
+
+RUN esy
+
 COPY esy.json esy.json
 COPY esy.lock esy.lock
 
 RUN esy fetch
-RUN esy build-package @esy-ocaml/substs
-RUN esy build-package @opam/conf-m4
-RUN esy build-package ocaml@4.7.1003
-RUN esy build-package @opam/ocamlfind
-RUN esy build-package @opam/base-bytes
-RUN esy build-package @opam/ocamlbuild
-RUN esy build-package @opam/base-threads
-RUN esy build-package @opam/base-unix
-RUN esy build-package @opam/dune
-RUN esy build-package @opam/jbuilder
-RUN esy build-package @opam/result
-RUN esy build-package @opam/topkg
-RUN esy build-package @opam/astring
-RUN esy build-package @opam/cmdliner
-RUN esy build-package @opam/uchar
-RUN esy build-package @opam/fmt
-RUN esy build-package @opam/uuidm
-RUN esy build-package @opam/alcotest
-RUN esy build-package @opam/base-bigarray
-RUN esy build-package @opam/bigstringaf
-RUN esy build-package @opam/faraday
-RUN esy build-package @opam/cppo
-RUN esy build-package @opam/lwt
-RUN esy build-package @opam/faraday-lwt
-RUN esy build-package @opam/faraday-lwt-unix
-RUN esy build-package @opam/angstrom
-RUN esy build-package @opam/httpaf
-RUN esy build-package @opam/httpaf-lwt
-RUN esy build-package @opam/logs
-RUN esy build-package @opam/cppo_ocamlbuild
-RUN esy build-package @opam/ocaml-migrate-parsetree
-RUN esy build-package @opam/ppx_derivers
-RUN esy build-package @opam/ppx_tools
-RUN esy build-package @opam/ppx_deriving
-RUN esy build-package @opam/ppxfind
-RUN esy build-package @opam/conf-which
-RUN esy build-package @opam/easy-format
-RUN esy build-package @opam/biniou
-RUN esy build-package @opam/yojson
-RUN esy build-package @opam/ppx_deriving_yojson
-RUN esy build-package @opam/sexplib0
-RUN esy build-package @opam/base
-RUN esy build-package @opam/ocaml-compiler-libs
-RUN esy build-package @opam/stdio
-RUN esy build-package @opam/ppxlib
-RUN esy build-package @opam/ppx_sexp_conv
-RUN esy build-package @opam/seq
-RUN esy build-package @opam/re
-RUN esy build-package @opam/stringext
-RUN esy build-package @opam/uri
-RUN esy build-package @opam/base64
+RUN esy true
 
 COPY . .
 

--- a/examples/error/Dockerfile
+++ b/examples/error/Dockerfile
@@ -31,60 +31,23 @@ ENV PATH=/esy/bin:$PATH
 RUN mkdir /app
 WORKDIR /app
 
+RUN echo ' \
+{\
+  "name": "package-base", \
+  "dependencies": { \
+    "ocaml": "~4.7.1000", \
+    "@opam/dune": "*" \
+  } \
+} \
+' > esy.json
+
+RUN esy
+
 COPY esy.json esy.json
 COPY esy.lock esy.lock
 
 RUN esy fetch
-RUN esy build-package @esy-ocaml/substs
-RUN esy build-package @opam/conf-m4
-RUN esy build-package ocaml@4.7.1003
-RUN esy build-package @opam/ocamlfind
-RUN esy build-package @opam/base-bytes
-RUN esy build-package @opam/ocamlbuild
-RUN esy build-package @opam/base-threads
-RUN esy build-package @opam/base-unix
-RUN esy build-package @opam/dune
-RUN esy build-package @opam/jbuilder
-RUN esy build-package @opam/result
-RUN esy build-package @opam/topkg
-RUN esy build-package @opam/astring
-RUN esy build-package @opam/cmdliner
-RUN esy build-package @opam/uchar
-RUN esy build-package @opam/fmt
-RUN esy build-package @opam/uuidm
-RUN esy build-package @opam/alcotest
-RUN esy build-package @opam/base-bigarray
-RUN esy build-package @opam/bigstringaf
-RUN esy build-package @opam/faraday
-RUN esy build-package @opam/cppo
-RUN esy build-package @opam/lwt
-RUN esy build-package @opam/faraday-lwt
-RUN esy build-package @opam/faraday-lwt-unix
-RUN esy build-package @opam/angstrom
-RUN esy build-package @opam/httpaf
-RUN esy build-package @opam/httpaf-lwt
-RUN esy build-package @opam/logs
-RUN esy build-package @opam/cppo_ocamlbuild
-RUN esy build-package @opam/ocaml-migrate-parsetree
-RUN esy build-package @opam/ppx_derivers
-RUN esy build-package @opam/ppx_tools
-RUN esy build-package @opam/ppx_deriving
-RUN esy build-package @opam/ppxfind
-RUN esy build-package @opam/conf-which
-RUN esy build-package @opam/easy-format
-RUN esy build-package @opam/biniou
-RUN esy build-package @opam/yojson
-RUN esy build-package @opam/ppx_deriving_yojson
-RUN esy build-package @opam/sexplib0
-RUN esy build-package @opam/base
-RUN esy build-package @opam/ocaml-compiler-libs
-RUN esy build-package @opam/stdio
-RUN esy build-package @opam/ppxlib
-RUN esy build-package @opam/ppx_sexp_conv
-RUN esy build-package @opam/seq
-RUN esy build-package @opam/re
-RUN esy build-package @opam/stringext
-RUN esy build-package @opam/uri
+RUN esy true
 
 COPY . .
 

--- a/examples/now-custom-runtime/Dockerfile
+++ b/examples/now-custom-runtime/Dockerfile
@@ -31,61 +31,23 @@ ENV PATH=/esy/bin:$PATH
 RUN mkdir /app
 WORKDIR /app
 
+RUN echo ' \
+{\
+  "name": "package-base", \
+  "dependencies": { \
+    "ocaml": "~4.7.1000", \
+    "@opam/dune": "*" \
+  } \
+} \
+' > esy.json
+
+RUN esy
+
 COPY esy.json esy.json
 COPY esy.lock esy.lock
 
 RUN esy fetch
-RUN esy build-package @esy-ocaml/substs
-RUN esy build-package @opam/conf-m4
-RUN esy build-package ocaml@4.7.1003
-RUN esy build-package @opam/ocamlfind
-RUN esy build-package @opam/base-bytes
-RUN esy build-package @opam/ocamlbuild
-RUN esy build-package @opam/base-threads
-RUN esy build-package @opam/base-unix
-RUN esy build-package @opam/dune
-RUN esy build-package @opam/jbuilder
-RUN esy build-package @opam/result
-RUN esy build-package @opam/topkg
-RUN esy build-package @opam/astring
-RUN esy build-package @opam/cmdliner
-RUN esy build-package @opam/uchar
-RUN esy build-package @opam/fmt
-RUN esy build-package @opam/uuidm
-RUN esy build-package @opam/alcotest
-RUN esy build-package @opam/base-bigarray
-RUN esy build-package @opam/bigstringaf
-RUN esy build-package @opam/faraday
-RUN esy build-package @opam/cppo
-RUN esy build-package @opam/lwt
-RUN esy build-package @opam/faraday-lwt
-RUN esy build-package @opam/faraday-lwt-unix
-RUN esy build-package @opam/angstrom
-RUN esy build-package @opam/httpaf
-RUN esy build-package @opam/httpaf-lwt
-RUN esy build-package @opam/logs
-RUN esy build-package @opam/cppo_ocamlbuild
-RUN esy build-package @opam/ocaml-migrate-parsetree
-RUN esy build-package @opam/ppx_derivers
-RUN esy build-package @opam/ppx_tools
-RUN esy build-package @opam/ppx_deriving
-RUN esy build-package @opam/ppxfind
-RUN esy build-package @opam/conf-which
-RUN esy build-package @opam/easy-format
-RUN esy build-package @opam/biniou
-RUN esy build-package @opam/yojson
-RUN esy build-package @opam/ppx_deriving_yojson
-RUN esy build-package @opam/sexplib0
-RUN esy build-package @opam/base
-RUN esy build-package @opam/ocaml-compiler-libs
-RUN esy build-package @opam/stdio
-RUN esy build-package @opam/ppxlib
-RUN esy build-package @opam/ppx_sexp_conv
-RUN esy build-package @opam/seq
-RUN esy build-package @opam/re
-RUN esy build-package @opam/stringext
-RUN esy build-package @opam/uri
-RUN esy build-package @opam/base64
+RUN esy true
 
 COPY . .
 

--- a/examples/now-lambda-reason/Dockerfile
+++ b/examples/now-lambda-reason/Dockerfile
@@ -31,62 +31,23 @@ ENV PATH=/esy/bin:$PATH
 RUN mkdir /app
 WORKDIR /app
 
+RUN echo ' \
+{\
+  "name": "package-base", \
+  "dependencies": { \
+    "ocaml": "~4.7.1000", \
+    "@opam/dune": "*" \
+  } \
+} \
+' > esy.json
+
+RUN esy
+
 COPY esy.json esy.json
 COPY esy.lock esy.lock
 
 RUN esy fetch
-RUN esy build-package @esy-ocaml/substs
-RUN esy build-package @opam/conf-m4
-RUN esy build-package ocaml@4.7.1003
-RUN esy build-package @opam/ocamlfind
-RUN esy build-package @opam/base-bytes
-RUN esy build-package @opam/ocamlbuild
-RUN esy build-package @opam/base-threads
-RUN esy build-package @opam/base-unix
-RUN esy build-package @opam/dune
-RUN esy build-package @opam/jbuilder
-RUN esy build-package @opam/result
-RUN esy build-package @opam/topkg
-RUN esy build-package @opam/astring
-RUN esy build-package @opam/cmdliner
-RUN esy build-package @opam/uchar
-RUN esy build-package @opam/fmt
-RUN esy build-package @opam/uuidm
-RUN esy build-package @opam/alcotest
-RUN esy build-package @opam/base-bigarray
-RUN esy build-package @opam/bigstringaf
-RUN esy build-package @opam/faraday
-RUN esy build-package @opam/cppo
-RUN esy build-package @opam/lwt
-RUN esy build-package @opam/faraday-lwt
-RUN esy build-package @opam/faraday-lwt-unix
-RUN esy build-package @opam/angstrom
-RUN esy build-package @opam/httpaf
-RUN esy build-package @opam/httpaf-lwt
-RUN esy build-package @opam/logs
-RUN esy build-package @opam/cppo_ocamlbuild
-RUN esy build-package @opam/ocaml-migrate-parsetree
-RUN esy build-package @opam/ppx_derivers
-RUN esy build-package @opam/ppx_tools
-RUN esy build-package @opam/ppx_deriving
-RUN esy build-package @opam/ppxfind
-RUN esy build-package @opam/conf-which
-RUN esy build-package @opam/easy-format
-RUN esy build-package @opam/biniou
-RUN esy build-package @opam/yojson
-RUN esy build-package @opam/ppx_deriving_yojson
-RUN esy build-package @opam/sexplib0
-RUN esy build-package @opam/base
-RUN esy build-package @opam/ocaml-compiler-libs
-RUN esy build-package @opam/stdio
-RUN esy build-package @opam/ppxlib
-RUN esy build-package @opam/ppx_sexp_conv
-RUN esy build-package @opam/seq
-RUN esy build-package @opam/re
-RUN esy build-package @opam/stringext
-RUN esy build-package @opam/uri
-RUN esy build-package @opam/base64
-RUN esy build-package @opam/reason
+RUN esy true
 
 COPY . .
 

--- a/examples/now-lambda-reason/basic.re
+++ b/examples/now-lambda-reason/basic.re
@@ -26,6 +26,7 @@ let send_request = (~meth=`GET, ~additional_headers=[], ~body=?, uri) => {
       Lwt_unix.connect(socket, List.hd(addresses).Unix.ai_addr)
       >>= (
         () => {
+          let connection = Client.create_connection(socket);
           let content_length =
             switch (body) {
             | None => "0"
@@ -49,7 +50,7 @@ let send_request = (~meth=`GET, ~additional_headers=[], ~body=?, uri) => {
 
           let request_body =
             Client.request(
-              socket,
+              connection,
               request_headers,
               ~error_handler,
               ~response_handler,

--- a/examples/now-lambda-reason/basic.re
+++ b/examples/now-lambda-reason/basic.re
@@ -26,42 +26,47 @@ let send_request = (~meth=`GET, ~additional_headers=[], ~body=?, uri) => {
       Lwt_unix.connect(socket, List.hd(addresses).Unix.ai_addr)
       >>= (
         () => {
-          let connection = Client.create_connection(socket);
-          let content_length =
-            switch (body) {
-            | None => "0"
-            | Some(body) => string_of_int(String.length(body))
-            };
+          Client.create_connection(socket)
+          >>= (
+            connection => {
+              let content_length =
+                switch (body) {
+                | None => "0"
+                | Some(body) => string_of_int(String.length(body))
+                };
 
-          let request_headers =
-            Request.create(
-              meth,
-              Uri.path_and_query(uri),
-              ~headers=
-                Headers.of_list(
-                  [("Host", host), ("Content-Length", content_length)]
-                  @ additional_headers,
-                ),
-            );
+              let request_headers =
+                Request.create(
+                  meth,
+                  Uri.path_and_query(uri),
+                  ~headers=
+                    Headers.of_list(
+                      [("Host", host), ("Content-Length", content_length)]
+                      @ additional_headers,
+                    ),
+                );
 
-          let (response_received, notify_response_received) = Lwt.wait();
-          let response_handler = response_handler(notify_response_received);
-          let error_handler = error_handler(notify_response_received);
+              let (response_received, notify_response_received) = Lwt.wait();
+              let response_handler =
+                response_handler(notify_response_received);
+              let error_handler = error_handler(notify_response_received);
 
-          let request_body =
-            Client.request(
-              connection,
-              request_headers,
-              ~error_handler,
-              ~response_handler,
-            );
+              let request_body =
+                Client.request(
+                  connection,
+                  request_headers,
+                  ~error_handler,
+                  ~response_handler,
+                );
 
-          switch (body) {
-          | Some(body) => Body.write_string(request_body, body)
-          | None => ()
-          };
-          Body.flush(request_body, () => Body.close_writer(request_body));
-          response_received;
+              switch (body) {
+              | Some(body) => Body.write_string(request_body, body)
+              | None => ()
+              };
+              Body.flush(request_body, () => Body.close_writer(request_body));
+              response_received;
+            }
+          );
         }
       );
     }

--- a/examples/now-lambda/Dockerfile
+++ b/examples/now-lambda/Dockerfile
@@ -31,6 +31,18 @@ ENV PATH=/esy/bin:$PATH
 RUN mkdir /app
 WORKDIR /app
 
+RUN echo ' \
+{\
+  "name": "package-base", \
+  "dependencies": { \
+    "ocaml": "~4.7.1000", \
+    "@opam/dune": "*" \
+  } \
+} \
+' > esy.json
+
+RUN esy
+
 COPY esy.json esy.json
 COPY esy.lock esy.lock
 

--- a/lambda-runtime.opam
+++ b/lambda-runtime.opam
@@ -21,5 +21,10 @@ depends: [
   "lwt"
   "alcotest" {with-test}
 ]
+pin-depends: [
+  [ "httpaf.dev" "git+https://github.com/anmonteiro/httpaf.git#fork" ]
+  [ "httpaf-lwt.dev" "git+https://github.com/anmonteiro/httpaf.git#fork" ]
+  [ "httpaf-lwt-unix.dev" "git+https://github.com/anmonteiro/httpaf.git#fork" ]
+]
 synopsis:
   "An OCaml custom runtime for AWS Lambda"

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -125,8 +125,8 @@ let make endpoint =
   Lwt_unix.getaddrinfo host port [ Unix.(AI_FAMILY PF_INET) ]
   >>= fun addresses ->
   let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-  Lwt_unix.connect socket (List.hd addresses).Unix.ai_addr >|= fun () ->
-  let connection = Httpaf_lwt_unix.Client.create_connection socket in
+  Lwt_unix.connect socket (List.hd addresses).Unix.ai_addr >>= fun () ->
+  Httpaf_lwt_unix.Client.create_connection socket >|= fun connection ->
   { endpoint; connection; host }
 
 let send_request

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -110,11 +110,32 @@ type event_context =
     identity : cognito_identity option
   }
 
-type t = string
+type t =
+  { endpoint : string
+  ; host : string
+  ; connection : Httpaf_lwt_unix.Client.t
+  }
 
-let make endpoint = endpoint
+let make endpoint =
+  let uri = Uri.of_string (Format.asprintf "http://%s" endpoint) in
+  let host = Uri.host_with_default uri in
+  let port =
+    match Uri.port uri with None -> "80" | Some p -> string_of_int p
+  in
+  Lwt_unix.getaddrinfo host port [ Unix.(AI_FAMILY PF_INET) ]
+  >>= fun addresses ->
+  let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Lwt_unix.connect socket (List.hd addresses).Unix.ai_addr >|= fun () ->
+  let connection = Httpaf_lwt_unix.Client.create_connection socket in
+  { endpoint; connection; host }
 
-let send_request ?(meth = `GET) ?(additional_headers = []) ?body uri =
+let send_request
+    { host; connection; _ }
+    ?(meth = `GET)
+    ?(additional_headers = [])
+    ?body
+    path
+  =
   let open Httpaf in
   let open Httpaf_lwt_unix in
   let response_handler notify_response_received response response_body =
@@ -123,14 +144,6 @@ let send_request ?(meth = `GET) ?(additional_headers = []) ?body uri =
   let error_handler notify_response_received error =
     Lwt.wakeup_later notify_response_received (Error error)
   in
-  let host = Uri.host_with_default uri in
-  let port =
-    match Uri.port uri with None -> "80" | Some p -> string_of_int p
-  in
-  Lwt_unix.getaddrinfo host port [ Unix.(AI_FAMILY PF_INET) ]
-  >>= fun addresses ->
-  let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-  Lwt_unix.connect socket (List.hd addresses).Unix.ai_addr >>= fun () ->
   let content_length =
     match body with
     | None ->
@@ -141,7 +154,7 @@ let send_request ?(meth = `GET) ?(additional_headers = []) ?body uri =
   let request_headers =
     Request.create
       meth
-      (Uri.path_and_query uri)
+      path
       ~headers:
         (Headers.of_list
            (("Host", host)
@@ -152,7 +165,7 @@ let send_request ?(meth = `GET) ?(additional_headers = []) ?body uri =
   let response_handler = response_handler notify_response_received in
   let error_handler = error_handler notify_response_received in
   let request_body =
-    Client.request socket request_headers ~error_handler ~response_handler
+    Client.request connection request_headers ~error_handler ~response_handler
   in
   (match body with
   | Some body ->
@@ -184,25 +197,24 @@ let read_response response_body =
   read_fn ();
   body_read
 
-let make_runtime_post_request uri output =
+let make_runtime_post_request client path output =
   let body = Yojson.Safe.to_string output in
   send_request
+    client
     ~meth:`POST
     ~additional_headers:[ "Content-Type", Constants.api_content_type ]
     ~body
-    uri
+    path
 
 let event_response client request_id output =
   let open Httpaf in
-  let uri =
-    Uri.of_string
-      (Printf.sprintf
-         "http://%s/%s/runtime/invocation/%s/response"
-         client
-         Constants.runtime_api_version
-         request_id)
+  let path =
+    Format.asprintf
+      "/%s/runtime/invocation/%s/response"
+      Constants.runtime_api_version
+      request_id
   in
-  make_runtime_post_request uri output >>= function
+  make_runtime_post_request client path output >>= function
   | Ok ({ Response.status; _ }, _) ->
     if not (Status.is_successful status) then
       let error =
@@ -225,28 +237,27 @@ let event_response client request_id output =
     in
     Lwt_result.fail err
 
-let make_runtime_error_request uri error =
+let make_runtime_error_request connection path error =
   let body = Errors.to_lambda_error error |> Yojson.Safe.to_string in
   send_request
+    connection
     ~meth:`POST
     ~additional_headers:
       [ "Content-Type", Constants.api_error_content_type
       ; Constants.runtime_error_header, "RuntimeError"
       ]
     ~body
-    uri
+    path
 
 let event_error client request_id err =
   let open Httpaf in
-  let uri =
-    Uri.of_string
-      (Printf.sprintf
-         "http://%s/%s/runtime/invocation/%s/error"
-         client
-         Constants.runtime_api_version
-         request_id)
+  let path =
+    Format.asprintf
+      "/%s/runtime/invocation/%s/error"
+      Constants.runtime_api_version
+      request_id
   in
-  make_runtime_error_request uri err >>= function
+  make_runtime_error_request client path err >>= function
   | Ok ({ Response.status; _ }, _) ->
     if not (Status.is_successful status) then
       let error =
@@ -270,14 +281,10 @@ let event_error client request_id err =
     Lwt_result.fail err
 
 let fail_init client err =
-  let uri =
-    Uri.of_string
-      (Printf.sprintf
-         "http://%s/%s/runtime/init/error"
-         client
-         Constants.runtime_api_version)
+  let path =
+    Format.asprintf "/%s/runtime/init/error" Constants.runtime_api_version
   in
-  make_runtime_error_request uri err >>= function
+  make_runtime_error_request client path err >>= function
   | Ok _ ->
     Lwt_result.return ()
   (* TODO: do we wanna "failwith" or just raise and then have a generic
@@ -346,17 +353,12 @@ let get_event_context headers =
 
 let next_event client =
   let open Httpaf in
-  let uri =
-    Uri.of_string
-      (Printf.sprintf
-         "http://%s/%s/runtime/invocation/next"
-         client
-         Constants.runtime_api_version)
+  let path =
+    Format.asprintf "/%s/runtime/invocation/next" Constants.runtime_api_version
   in
-  Logs_lwt.info (fun m ->
-      m "Polling for next event. Uri: %s\n" (Uri.to_string uri))
+  Logs_lwt.info (fun m -> m "Polling for next event. Path: %s\n" path)
   >>= fun () ->
-  send_request uri >>= function
+  send_request client path >>= function
   | Ok ({ Response.status; headers; _ }, body) ->
     let code = Status.to_code status in
     if Status.is_client_error status then

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -146,19 +146,22 @@ struct
         else
           start runtime )
 
-  let start_with_runtime_client ~lift handler function_config client =
+  let start_with_runtime_endpoint ~lift handler function_config endpoint =
+    Client.make endpoint >>= fun client ->
     let runtime =
-      make ~max_retries:3 ~settings:function_config client ~lift ~handler
+      make ~max_retries:3 ~settings:function_config ~lift ~handler client
     in
-    Lwt_main.run (start runtime)
+    start runtime
 
   let start_lambda ~lift handler =
     match Config.get_runtime_api_endpoint () with
     | Ok endpoint ->
       (match Config.get_function_settings () with
       | Ok function_config ->
-        let client = Client.make endpoint in
-        start_with_runtime_client ~lift handler function_config client
+        let p =
+          start_with_runtime_endpoint ~lift handler function_config endpoint
+        in
+        Lwt_main.run p
       | Error msg ->
         failwith msg)
     | Error msg ->

--- a/now.opam
+++ b/now.opam
@@ -19,11 +19,16 @@ depends: [
   "lambda-runtime"
   "alcotest" {with-test}
 ]
+pin-depends: [
+  [ "httpaf.dev" "git+https://github.com/anmonteiro/httpaf.git#fork" ]
+  [ "httpaf-lwt.dev" "git+https://github.com/anmonteiro/httpaf.git#fork" ]
+  [ "httpaf-lwt-unix.dev" "git+https://github.com/anmonteiro/httpaf.git#fork" ]
+]
 synopsis:
-  "An OCaml custom runtime for AWS Lambda"
+  "An OCaml custom runtime for Zeit.sh Now v2."
 description:
   """
-  lambda-runtime is an OCaml custom runtime for AWS Lambda. The now package
+  lambda-runtime is an OCaml custom runtime for AWS Lambda. The `now` package
   provides an adapter and API for lambda-runtime that works with ZEIT's now.sh
   v2 service.
   """


### PR DESCRIPTION
This results in a 20-25% speedup for the simplest case and helps the
runtime break the 1ms execution barrier