### PR TITLE
tolerate unknown fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         ocamlVersion: [4_12, 4_13, 4_14, 5_00]
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v14.1
+    - uses: cachix/install-nix-action@v16
       with:
         skip_adding_nixpkgs_channel: true
     - uses: cachix/cachix-action@v10

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Unreleased
+--------------
+
+- Tolerate unknown fields when parsing JSON payloads
+  (`@@deriving yojson {strict = false; }`)
+  ([#62](https://github.com/anmonteiro/aws-lambda-ocaml-runtime/pull/62))
+
 0.1.0 2021-04-17
 --------------
 

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -70,7 +70,7 @@ type client_application =
   ; (* The package name for the mobile application invoking the function *)
     app_package_name : string
   }
-[@@deriving of_yojson]
+[@@deriving of_yojson { strict = false }]
 
 type client_context =
   { (* Information about the mobile application invoking the function. *)
@@ -80,7 +80,7 @@ type client_context =
   ; (* Environment settings from the mobile client. *)
     env : Yojson.Safe.t
   }
-[@@deriving of_yojson]
+[@@deriving of_yojson { strict = false }]
 
 (* Cognito identity information sent with the event *)
 type cognito_identity =
@@ -90,7 +90,7 @@ type cognito_identity =
   ; (* The identity pool id the caller is "registered" with. *)
     identity_pool_id : string
   }
-[@@deriving of_yojson]
+[@@deriving of_yojson { strict = false }]
 
 type event_context =
   { (* The ARN of the Lambda function being invoked. *)

--- a/lib/http.ml
+++ b/lib/http.ml
@@ -50,7 +50,7 @@ type api_gateway_request_identity =
   ; user_agent : string option [@key "userAgent"]
   ; user : string option
   }
-[@@deriving of_yojson]
+[@@deriving of_yojson { strict = false }]
 
 (* APIGatewayProxyRequestContext contains the information to identify the AWS
  * account and resources invoking the Lambda function. It also includes Cognito

--- a/lib/http.ml
+++ b/lib/http.ml
@@ -97,7 +97,7 @@ type api_gateway_proxy_response =
 [@@deriving to_yojson]
 
 module API_gateway_request = struct
-  type t = api_gateway_proxy_request [@@deriving of_yojson]
+  type t = api_gateway_proxy_request [@@deriving of_yojson { strict = false }]
 end
 
 module API_gateway_response = struct

--- a/test/fixtures/apigw.json
+++ b/test/fixtures/apigw.json
@@ -40,6 +40,7 @@
     "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
     "identity": {
       "cognitoIdentityPoolId": null,
+      "cognitoAmr": null,
       "accountId": null,
       "cognitoIdentityId": null,
       "caller": null,


### PR DESCRIPTION
`strict` mode was not disabled for `api_gateway_request_identity`, so some new fields like `cognitoAmr` are causing body parsing to fail.